### PR TITLE
Updated python-pip3.sh

### DIFF
--- a/python-pip3.sh
+++ b/python-pip3.sh
@@ -1,4 +1,4 @@
-sudo apt-get update && apt-get upgrade
+sudo apt-get update && apt-get dist-upgrade
 sudo apt-get install python3-distutils
 wget https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py --user


### PR DESCRIPTION
Line 1 of python-pip3.sh (more specific apt-get upgrade) threw an error:
E: Could not open lock file /var/lib/dpkg/lon-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?

Proposed change fixed the problem.